### PR TITLE
Add Legacy Fabric

### DIFF
--- a/fabricutil.py
+++ b/fabricutil.py
@@ -1,6 +1,31 @@
 from metautil import *
 import jsonobject
 
+variants = {
+    "fabric": {
+        "name": "Fabric Loader",
+        "description": "Fabric Loader is a tool to load Fabric-compatible mods in game environments.",
+        "url": "https://fabricmc.net",
+        "authors": ["Fabric Developers"],
+        "meta": "https://meta.fabricmc.net",
+        "maven": "https://maven.fabricmc.net",
+        "loader_uid": "net.fabricmc.fabric-loader",
+        "intermediary_uid": "net.fabricmc.intermediary",
+        "exclude": [],
+    },
+    "legacy-fabric": {
+        "name": "Fabric Loader 1.8.9",
+        "description": "Fabric Loader for 1.8.9 and below.",
+        "url": "https://legacyfabric.net",
+        "authors": ["Legacy Fabric Developers"],
+        "meta": "https://meta.legacyfabric.net",
+        "maven": "https://maven.legacyfabric.net",
+        "loader_uid": "net.legacyfabric.fabric-loader-189",
+        "intermediary_uid": "net.legacyfabric.intermediary",
+        "exclude": ["fabric-loader"],
+    },
+}
+
 # barebones semver-like parser
 def isFabricVerStable(ver):
     s = ver.split("+")

--- a/updateFabric.py
+++ b/updateFabric.py
@@ -24,7 +24,7 @@ def filehash(filename, hashtype, blocksize=65536):
 
 def get_maven_url(mavenKey, server, ext):
     mavenParts = mavenKey.split(":", 3)
-    mavenVerUrl = server + mavenParts[0].replace(".", "/") + "/" + mavenParts[1] + "/" + mavenParts[2] + "/"
+    mavenVerUrl = server + "/" + mavenParts[0].replace(".", "/") + "/" + mavenParts[1] + "/" + mavenParts[2] + "/"
     mavenUrl = mavenVerUrl + mavenParts[1] + "-" + mavenParts[2] + ext
     return mavenUrl
 
@@ -62,20 +62,34 @@ def compute_jar_file(path, url):
     with open(path + ".json", 'w') as outfile:
         json.dump(data.to_json(), outfile, sort_keys=True, indent=4)
 
-mkdirs("upstream/fabric/meta-v2")
-mkdirs("upstream/fabric/loader-installer-json")
-mkdirs("upstream/fabric/jars")
+for variantName, variant in variants.items():
+    mkdirs(f"upstream/{variantName}/meta-v2")
+    mkdirs(f"upstream/{variantName}/loader-installer-json")
+    mkdirs(f"upstream/{variantName}/jars")
 
-# get the version list for each component we are interested in
-for component in ["intermediary", "loader"]:
-    index = get_json_file("upstream/fabric/meta-v2/" + component + ".json", "https://meta.fabricmc.net/v2/versions/" + component)
-    for it in index:
-        jarMavenUrl = get_maven_url(it["maven"], "https://maven.fabricmc.net/", ".jar")
-        compute_jar_file("upstream/fabric/jars/" + it["maven"].replace(":", "."), jarMavenUrl)
+    print(f"--- {variantName} ---")
 
-# for each loader, download installer JSON file from maven
-with open("upstream/fabric/meta-v2/loader.json", 'r', encoding='utf-8') as loaderVersionIndexFile:
-    loaderVersionIndex = json.load(loaderVersionIndexFile)
-    for it in loaderVersionIndex:
-        mavenUrl = get_maven_url(it["maven"], "https://maven.fabricmc.net/", ".json")
-        get_json_file("upstream/fabric/loader-installer-json/" + it["version"] + ".json", mavenUrl)
+    # get the version list for each component we are interested in
+    for component in ["intermediary", "loader"]:
+        print(f"Downloading {component} versions...")
+        index = get_json_file(f"upstream/{variantName}/meta-v2/" + component + ".json", f"{variant['meta']}/v2/versions/" + component)
+        for it in index:
+            if "name" in it and it["name"] in variant["exclude"]:
+                continue
+
+            print(f"Downloading {it['maven']} jar...")
+            jarMavenUrl = get_maven_url(it["maven"], variant["maven"], ".jar")
+            compute_jar_file(f"upstream/{variantName}/jars/" + it["maven"].replace(":", "."), jarMavenUrl)
+
+    print("Downloading installer metadata...")
+
+    # for each loader, download installer JSON file from maven
+    with open(f"upstream/{variantName}/meta-v2/loader.json", 'r', encoding='utf-8') as loaderVersionIndexFile:
+        loaderVersionIndex = json.load(loaderVersionIndexFile)
+        for it in loaderVersionIndex:
+            if "name" in it and it["name"] in variant["exclude"]:
+                continue
+
+            print(f"Downloading {it['maven']} installer metadata...")
+            mavenUrl = get_maven_url(it["maven"], variant["maven"], ".json")
+            get_json_file(f"upstream/{variantName}/loader-installer-json/" + it["version"] + ".json", mavenUrl)


### PR DESCRIPTION
Legacy Fabric is a fork of Fabric adding support for older versions of the game (currently supporting 1.12.2, 1.8.9, 1.7.10, and 1.6.4, with most development happening for 1.8.9). This PR splits Fabric into "variants" and generates independent metadata for each variant. This variant system was intended to allow future extensibility for projects like Cursed Legacy Fabric, which targets Beta 1.7.3.

I haven't added Legacy Fabric to the MultiMC GUI yet, and I'm not sure the best route to do so (automatically change Install Fabric to Install Legacy Fabric for supported versions, maybe?). However, I've tested the [generated metadata](https://github.com/leo60228/meta-multimc/tree/legacy-fabric) and it works fine.

Additionally, Fabric Loader depends on a newer version of Guava than the default for 1.7.10. This can be installed manually, though I've submitted a PR at https://github.com/Legacy-Fabric/fabric-loader-1.8.9/pull/10 to get Guava from Maven. My meta-multimc was generated with that PR applied, so it should work fine.