### PR TITLE
Fix fabric generation not handling unstable versions.

### DIFF
--- a/fabricutil.py
+++ b/fabricutil.py
@@ -1,11 +1,6 @@
 from metautil import *
 import jsonobject
 
-# barebones semver-like parser
-def isFabricVerStable(ver):
-    s = ver.split("+")
-    return ("-" not in s[0])
-
 class FabricInstallerArguments(JsonObject):
     client = ListProperty(StringProperty)
     common = ListProperty(StringProperty)

--- a/generateFabric.py
+++ b/generateFabric.py
@@ -23,7 +23,7 @@ def loadJarInfo(mavenKey):
         return FabricJarInfo(json.load(jarInfoFile))
 
 def processLoaderVersion(loaderVersion, it, loaderData):
-    verStable = isFabricVerStable(loaderVersion)
+    verStable = it["stable"]
     if (len(loaderRecommended) < 1) and verStable:
         loaderRecommended.append(loaderVersion)
     versionJarInfo = loadJarInfo(it["maven"])
@@ -31,10 +31,7 @@ def processLoaderVersion(loaderVersion, it, loaderData):
     version.releaseTime = versionJarInfo.releaseTime
     version.requires = [DependencyEntry(uid='net.fabricmc.intermediary')]
     version.order = 10
-    if verStable:
-        version.type = "release"
-    else:
-        version.type = "snapshot"
+    version.type = "release"
     if isinstance(loaderData.mainClass, dict):
         version.mainClass = loaderData.mainClass["client"]
     else:


### PR DESCRIPTION
We recentally released `0.12.0` as unstable see: [https://meta.fabricmc.net/v2/versions/loader](https://meta.fabricmc.net/v2/versions/loader)

However multimc is always marking the latest version as the recommended version. These changes now show the latest stable version as recommended.

I have confirmed this to now be reflected correctly in "package.json" and the `recommended` key in the "index.json" file.

Please let me know if you have any queries 👍