### PR TITLE
hotfix: fixing the pre-1.6 entries for the rd entries

### DIFF
--- a/static/minecraft.json
+++ b/static/minecraft.json
@@ -327,21 +327,21 @@
         },
         "rd-160052": {
             "releaseTime": "2009-05-16T00:52:00+02:00",
-            "mainClass": "com.mojang.rubydung.RubyDung",
+            "mainClass": "com.mojang.minecraft.RubyDung",
             "+traits": ["no-texturepacks"]
         },
         "rd-20090515": {
-            "mainClass": "com.mojang.rubydung.RubyDung",
+            "mainClass": "com.mojang.minecraft.RubyDung",
             "+traits": ["no-texturepacks"]
         },
         "rd-132328": {
             "releaseTime": "2009-05-13T23:28:00+02:00",
-            "mainClass": "com.mojang.rubydung.RubyDung",
+            "mainClass": "com.mojang.minecraft.RubyDung",
             "+traits": ["no-texturepacks"]
         },
         "rd-132211": {
             "releaseTime": "2009-05-13T22:11:00+02:00",
-            "mainClass": "com.mojang.rubydung.RubyDung",
+            "mainClass": "com.mojang.minecraft.RubyDung",
             "+traits": ["no-texturepacks"]
         }
     }


### PR DESCRIPTION
This issue was brought up in and fixes MultiMC/Launcher#5405 

Typo found in the mainClass for all but one of the rd entries in the pre-1.6 static json.