### PR TITLE
hotfix: fixing the pre-1.6 entries for the rd entries

### DIFF
--- a/static/minecraft.json
+++ b/static/minecraft.json
@@ -331,7 +331,7 @@
             "+traits": ["no-texturepacks"]
         },
         "rd-20090515": {
-            "mainClass": "com.mojang.rubydung.RubyDung",
+            "mainClass": "com.mojang.minecraft.RubyDung",
             "+traits": ["no-texturepacks"]
         },
         "rd-132328": {


### PR DESCRIPTION
This issue was brought up in and fixes https://github.com/MultiMC/Launcher/issues/5405

Typo found in the mainClass for all but one of the rd entry of RD-20090515 in the pre-1.6 static json.